### PR TITLE
Change DBG2 tables to use the 5250 UART subtype

### DIFF
--- a/Platform/MacBookAirMid2020Pkg/AcpiTables/DBG2.aslc
+++ b/Platform/MacBookAirMid2020Pkg/AcpiTables/DBG2.aslc
@@ -87,7 +87,7 @@ STATIC DBG2_TABLE Dbg2 = {
     // Kernel Debug Port
     DBG2_DEBUG_PORT_DDI (
       DBG2_NUMBER_OF_GENERIC_ADDRESS_REGISTERS,
-      0x16, /* Using a reserved port subtype for now so we can uniquely define the 8900 UART in our KDCOM transport without the SAM5250 built-in support causing issues. */
+      0xA, /* SAM5250, seems to be more or less compatible with the 8900 UART (which isn't 5250 based but is close enough for WinDbg) */
       FixedPcdGet64 (PcdAppleUartBase),
       SERIAL_PORT_8900_UART_ADDR_SIZE,
       APPLE_8900_UART_STRING

--- a/Platform/MacBookProEarly2023Pkg/AcpiTables/DBG2.aslc
+++ b/Platform/MacBookProEarly2023Pkg/AcpiTables/DBG2.aslc
@@ -89,7 +89,7 @@ STATIC DBG2_TABLE Dbg2 = {
     // Kernel Debug Port
     DBG2_DEBUG_PORT_DDI (
       DBG2_NUMBER_OF_GENERIC_ADDRESS_REGISTERS,
-      0x16, /* Using a reserved port subtype for now so we can uniquely define the 8900 UART in our KDCOM transport without the SAM5250 built-in support causing issues. */
+      0xA, /* SAM5250, seems to be more or less compatible with the 8900 UART (which isn't 5250 based but is close enough for WinDbg) */
       FixedPcdGet64 (PcdAppleUartBase),
       SERIAL_PORT_8900_UART_ADDR_SIZE,
       APPLE_8900_UART_STRING

--- a/Platform/MacStudio2022Pkg/AcpiTables/DBG2.aslc
+++ b/Platform/MacStudio2022Pkg/AcpiTables/DBG2.aslc
@@ -90,7 +90,7 @@ STATIC DBG2_TABLE Dbg2 = {
     // Kernel Debug Port
     DBG2_DEBUG_PORT_DDI (
       DBG2_NUMBER_OF_GENERIC_ADDRESS_REGISTERS,
-      0x16, /* Using a reserved port subtype for now so we can uniquely define the 8900 UART in our KDCOM transport without the SAM5250 built-in support causing issues. */
+      0xA, /* SAM5250, seems to be more or less compatible with the 8900 UART (which isn't 5250 based but is close enough for WinDbg) */
       FixedPcdGet64 (PcdAppleUartBase),
       SERIAL_PORT_8900_UART_ADDR_SIZE,
       APPLE_8900_UART_STRING


### PR DESCRIPTION
Just a quick PR to change the DBG2 subtypes to the SAM5250 UART subtype, making sure that it's ok to merge this, looking for feedback