### PR TITLE
Fix SMP

### DIFF
--- a/Platform/MacBookProEarly2023Pkg/AcpiTables/DSDT.asl
+++ b/Platform/MacBookProEarly2023Pkg/AcpiTables/DSDT.asl
@@ -137,7 +137,7 @@
                 0x0000000000000000,   // AddressTranslation - TRA
                 0x0000000000001000    // RangeLength - LEN
                 )
-                Interrupt(ResourceConsumer, Level, ActiveHigh, Exclusive) { 1097 }            
+                Interrupt(ResourceConsumer, Level, ActiveHigh, Exclusive) { 1198 }            
             })
             Method (_STA) {
                 Return (0xF)

--- a/Platform/MacBookProEarly2023Pkg/MacBookProEarly2023.dsc
+++ b/Platform/MacBookProEarly2023Pkg/MacBookProEarly2023.dsc
@@ -26,7 +26,7 @@
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = MacBookProEarly2023Pkg/MacBookProEarly2023.fdf
   SECURE_BOOT_ENABLE             = FALSE #disable secure boot for now
-  AIC_BUILD                      = TRUE #AIC build enabled by default, change to false if you want to use a vGIC
+  AIC_BUILD                      = FALSE #AIC build enabled by default, change to false if you want to use a vGIC
   NETWORK_TLS_ENABLE             = TRUE
 
 [BuildOptions.common]

--- a/Silicon/Apple/AppleSiliconPkg/Include/Acpi/AcpiHeader.h
+++ b/Silicon/Apple/AppleSiliconPkg/Include/Acpi/AcpiHeader.h
@@ -43,4 +43,10 @@
     EFI_ACPI_CREATOR_REVISION /* UINT32  CreatorRevision */ \
   }
 
+#define GET_MPIDR(aff3, aff2, aff1, aff0) \
+    ((((UINT64)(aff3) & 0xff) << 32) |    \
+     (((UINT64)(aff2) & 0xff) << 16) |    \
+     (((UINT64)(aff1) & 0xff) <<  8) |    \
+     (((UINT64)(aff0) & 0xff) <<  0))
+
 #endif /* ACPI_HEADER_H_ */

--- a/Silicon/Apple/AppleSiliconPkg/Include/Acpi/SgiAcpiHeader.h
+++ b/Silicon/Apple/AppleSiliconPkg/Include/Acpi/SgiAcpiHeader.h
@@ -1,0 +1,184 @@
+/** @file
+*
+*  Copyright (c) 2018 - 2022, Arm Limited. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+
+#ifndef __SGI_ACPI_HEADER__
+#define __SGI_ACPI_HEADER__
+
+#include <IndustryStandard/Acpi.h>
+
+
+// Cache type identifier used to calculate unique cache ID for PPTT
+typedef enum {
+  L1DataCache = 1,
+  L1InstructionCache,
+  L2Cache,
+  L3Cache,
+} RD_PPTT_CACHE_TYPE;
+
+//
+// PPTT processor structure flags for different SoC components as defined in
+// ACPI 6.4 specification
+//
+
+// Processor structure flags for SoC package
+#define PPTT_PROCESSOR_PACKAGE_FLAGS                                           \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_PHYSICAL,                                        \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_INVALID,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_NOT_THREAD,                                 \
+    EFI_ACPI_6_4_PPTT_NODE_IS_NOT_LEAF,                                        \
+    EFI_ACPI_6_4_PPTT_IMPLEMENTATION_IDENTICAL                                 \
+  }
+
+// Processor structure flags for cluster
+#define PPTT_PROCESSOR_CLUSTER_FLAGS                                           \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_NOT_PHYSICAL,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_VALID,                                      \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_NOT_THREAD,                                 \
+    EFI_ACPI_6_4_PPTT_NODE_IS_NOT_LEAF,                                        \
+    EFI_ACPI_6_4_PPTT_IMPLEMENTATION_IDENTICAL                                 \
+  }
+
+// Processor structure flags for cluster with multi-thread core
+#define PPTT_PROCESSOR_CLUSTER_THREADED_FLAGS                                  \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_NOT_PHYSICAL,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_INVALID,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_NOT_THREAD,                                 \
+    EFI_ACPI_6_4_PPTT_NODE_IS_NOT_LEAF,                                        \
+    EFI_ACPI_6_4_PPTT_IMPLEMENTATION_IDENTICAL                                 \
+  }
+
+// Processor structure flags for single-thread core
+#define PPTT_PROCESSOR_CORE_FLAGS                                              \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_NOT_PHYSICAL,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_VALID,                                      \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_NOT_THREAD,                                 \
+    EFI_ACPI_6_4_PPTT_NODE_IS_LEAF                                             \
+  }
+
+// Processor structure flags for multi-thread core
+#define PPTT_PROCESSOR_CORE_THREADED_FLAGS                                     \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_NOT_PHYSICAL,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_INVALID,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_NOT_THREAD,                                 \
+    EFI_ACPI_6_4_PPTT_NODE_IS_NOT_LEAF,                                        \
+    EFI_ACPI_6_4_PPTT_IMPLEMENTATION_IDENTICAL                                 \
+  }
+
+// Processor structure flags for CPU thread
+#define PPTT_PROCESSOR_THREAD_FLAGS                                            \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_PACKAGE_NOT_PHYSICAL,                                    \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_ID_VALID,                                      \
+    EFI_ACPI_6_4_PPTT_PROCESSOR_IS_THREAD,                                     \
+    EFI_ACPI_6_4_PPTT_NODE_IS_LEAF                                             \
+  }
+
+// PPTT cache structure flags as defined in ACPI 6.4 Specification
+#define PPTT_CACHE_STRUCTURE_FLAGS                                             \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_CACHE_SIZE_VALID,                                        \
+    EFI_ACPI_6_4_PPTT_NUMBER_OF_SETS_VALID,                                    \
+    EFI_ACPI_6_4_PPTT_ASSOCIATIVITY_VALID,                                     \
+    EFI_ACPI_6_4_PPTT_ALLOCATION_TYPE_VALID,                                   \
+    EFI_ACPI_6_4_PPTT_CACHE_TYPE_VALID,                                        \
+    EFI_ACPI_6_4_PPTT_WRITE_POLICY_VALID,                                      \
+    EFI_ACPI_6_4_PPTT_LINE_SIZE_VALID,                                         \
+    EFI_ACPI_6_4_PPTT_CACHE_ID_VALID                                           \
+  }
+
+// PPTT cache attributes for data cache
+#define PPTT_DATA_CACHE_ATTR                                                   \
+  {                                                                            \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,                       \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_CACHE_TYPE_DATA,                             \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK                      \
+  }
+
+// PPTT cache attributes for instruction cache
+#define PPTT_INST_CACHE_ATTR                                                   \
+  {                                                                            \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_ALLOCATION_READ,                             \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_CACHE_TYPE_INSTRUCTION,                      \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK                      \
+  }
+
+// PPTT cache attributes for unified cache
+#define PPTT_UNIFIED_CACHE_ATTR                                                \
+  {                                                                            \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_ALLOCATION_READ_WRITE,                       \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_CACHE_TYPE_UNIFIED,                          \
+    EFI_ACPI_6_4_CACHE_ATTRIBUTES_WRITE_POLICY_WRITE_BACK                      \
+  }
+
+/** Helper macro to calculate a unique cache ID
+
+  Macro to calculate a unique 32 bit cache ID. The 32-bit encoding format of the
+  cache ID is
+  * Bits[31:24]: Unused
+  * Bits[23:20]: Package number the cache belongs to
+  * Bits[19:12]: Cluster number the cache belongs to (0, if not a cluster cache)
+  * Bits[11:4] : Core number the cache belongs to (0, if not a CPU cache)
+  * Bits[3:0]  : Cache Type (as defined by RD_PPTT_CACHE_TYPE)
+
+  Note: Cache ID zero is invalid as per ACPI 6.4 specification. Also this
+  calculation is not based on any specification.
+
+  @param [in] PackageId Package instance number.
+  @param [in] ClusterId Cluster instance number (for Cluster cache, 0 otherwise)
+  @param [in] CpuId     CPU instance number (for CPU cache, 0 otherwise).
+  @param [in] CacheType Identifier for cache type as defined by
+                        RD_PPTT_CACHE_TYPE.
+**/
+#define RD_PPTT_CACHE_ID(PackageId, ClusterId, CoreId, CacheType)              \
+    (                                                                          \
+      (((PackageId) & 0xF) << 20) | (((ClusterId) & 0xFF) << 12) |             \
+      (((CoreId) & 0xFF) << 4) | ((CacheType) & 0xF)                           \
+    )
+
+// EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR
+#define EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT(Length, Flag, Parent,       \
+  ACPIProcessorID, NumberOfPrivateResource)                                    \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_TYPE_PROCESSOR,                 /* Type 0 */             \
+    Length,                                           /* Length */             \
+    {                                                                          \
+      EFI_ACPI_RESERVED_BYTE,                                                  \
+      EFI_ACPI_RESERVED_BYTE,                                                  \
+    },                                                                         \
+    Flag,                                             /* Processor flags */    \
+    Parent,                                           /* Ref to parent node */ \
+    ACPIProcessorID,                                  /* UID, as per MADT */   \
+    NumberOfPrivateResource                           /* Resource count */     \
+  }
+
+// EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE
+#define EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT(Flag, NextLevelCache, Size,     \
+  NoOfSets, Associativity, Attributes, LineSize, CacheId)                      \
+  {                                                                            \
+    EFI_ACPI_6_4_PPTT_TYPE_CACHE,                     /* Type 1 */             \
+    sizeof (EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE),       /* Length */             \
+    {                                                                          \
+      EFI_ACPI_RESERVED_BYTE,                                                  \
+      EFI_ACPI_RESERVED_BYTE,                                                  \
+    },                                                                         \
+    Flag,                                             /* Cache flags */        \
+    NextLevelCache,                                   /* Ref to next level */  \
+    Size,                                             /* Size in bytes */      \
+    NoOfSets,                                         /* Num of sets */        \
+    Associativity,                                    /* Num of ways */        \
+    Attributes,                                       /* Cache attributes */   \
+    LineSize,                                         /* Line size in bytes */ \
+    CacheId                                           /* Cache id */           \
+  }
+
+#endif /* __SGI_ACPI_HEADER__ */

--- a/Silicon/Apple/T602XFamilyPkg/AcpiTables/CPUAcpiTables.inf
+++ b/Silicon/Apple/T602XFamilyPkg/AcpiTables/CPUAcpiTables.inf
@@ -17,7 +17,7 @@
   VERSION_STRING                 = 1.0
 
 [Sources]
-  #GTDT.aslc
+  GTDT.aslc
   #CSRT.aslc
   MADT_Static.aslc
 

--- a/Silicon/Apple/T602XFamilyPkg/AcpiTables/CPUAcpiTables.inf
+++ b/Silicon/Apple/T602XFamilyPkg/AcpiTables/CPUAcpiTables.inf
@@ -20,6 +20,7 @@
   GTDT.aslc
   #CSRT.aslc
   MADT_Static.aslc
+  PPTT.aslc
 
 
 [Packages]

--- a/Silicon/Apple/T602XFamilyPkg/AcpiTables/GTDT.aslc
+++ b/Silicon/Apple/T602XFamilyPkg/AcpiTables/GTDT.aslc
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2023, amarioguy (AppleWOA authors).
+ * 
+ * Module Name:
+ *     GTDT.aslc
+ * 
+ * Abstract:
+ *     Generic Timer Description Table. This source file implements the GTDT table for
+ *     "Rhodes" (M2 Pro/Max/Ultra) SoCs.
+ * 
+ * Environment:
+ *     UEFI firmware/runtime services.
+ * 
+ * License:
+ *     SPDX-License-Identifier: BSD-2-Clause-Patent OR MIT
+ * 
+ * Based on AmpereAltraPkg (part of edk2-platforms) and QemuSbsaPkg (part of mu_tiano_platforms)
+ * 
+*/
+
+#include <Library/PcdLib.h>
+#include <Library/AcpiLib.h>
+#include <IndustryStandard/Acpi64.h>
+#include <Acpi/AcpiHeader.h>
+
+
+/**
+ * Apple platforms basically just implement the standard ARM timer, with the only major distinction
+ * being that the timer interrupts (and most things considered a "PPI" on GIC systems) are using
+ * FIQs and not IRQs.
+ * 
+ * As a result we will assign an arbitrary interrupt number (17 currently) and then proceed to define a standard ARM timer here.
+*/
+
+#define SYSTEM_TIMER_BASE_ADDRESS       0xFFFFFFFFFFFFFFFF
+#define CNT_READ_BASE_ADDRESS           0xFFFFFFFFFFFFFFFF
+
+#define GTDT_TIMER_EDGE_TRIGGERED   EFI_ACPI_6_4_GTDT_TIMER_FLAG_TIMER_INTERRUPT_MODE
+#define GTDT_TIMER_LEVEL_TRIGGERED  0
+#define GTDT_TIMER_ACTIVE_LOW       EFI_ACPI_6_4_GTDT_TIMER_FLAG_TIMER_INTERRUPT_POLARITY
+#define GTDT_TIMER_ACTIVE_HIGH      0
+#define GTDT_TIMER_SAVE_CONTEXT     EFI_ACPI_6_4_GTDT_TIMER_FLAG_ALWAYS_ON_CAPABILITY
+#define GTDT_TIMER_LOSE_CONTEXT     0
+
+#define GTDT_GTIMER_FLAGS          (GTDT_TIMER_LOSE_CONTEXT | GTDT_TIMER_ACTIVE_HIGH | GTDT_TIMER_LEVEL_TRIGGERED)
+
+/**
+ * Per the Linux driver for the Apple WDT, Apple platforms have three watchdog timers on the platform,
+ * they seem to be contiguously mapped in the same MMIO space.
+ * 
+ * Watchdog 0 is a "boot to recovery mode" watchdog, not useful.
+ * 
+ * Watchdog 1 is the one we will use and set as the "generic" watchdog in this specific table.
+ * 
+ * There is an alternate watchdog timer that serves the same purpose as Watchdog 1, can use either, but will use Watchdog 1.
+ * 
+ * Reset flow of the Apple watchdog timer:
+ *   1) Write 0x4 to wdt_base + 0x1c
+ *   2) write zeros to the wdt_base + 0x10 and wdt_base + 0x14
+ * 
+*/
+#define WATCHDOG_COUNT              0
+
+
+#define ARM_WATCHDOG_REFRESH_BASE     0x000000029E2C4010
+#define ARM_WATCHDOG_CONTROL_BASE     0x000000029E2C401C
+#define ARM_WATCHDOG_GSIV             719
+
+#define ARM_WATCHDOG_EDGE_TRIGGERED   EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG_FLAG_TIMER_INTERRUPT_MODE
+#define ARM_WATCHDOG_LEVEL_TRIGGERED  0
+#define ARM_WATCHDOG_ACTIVE_LOW       EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG_FLAG_TIMER_INTERRUPT_POLARITY
+#define ARM_WATCHDOG_ACTIVE_HIGH      0
+#define ARM_WATCHDOG_SECURE           EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG_FLAG_SECURE_TIMER
+#define ARM_WATCHDOG_NON_SECURE       0
+
+#define ARM_WATCHDOG_FLAGS            (ARM_WATCHDOG_NON_SECURE | ARM_WATCHDOG_ACTIVE_HIGH | ARM_WATCHDOG_LEVEL_TRIGGERED)
+
+#pragma pack (1)
+
+typedef struct {
+  EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLE          Gtdt;
+#if (WATCHDOG_COUNT != 0)
+  EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG_STRUCTURE     Watchdogs[WATCHDOG_COUNT];
+#endif
+} EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLES;
+
+#pragma pack ()
+
+EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLES Gtdt = {
+  {
+    __ACPI_HEADER (
+      EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLE_SIGNATURE,
+      EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLES,
+      EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLE_REVISION
+    ),
+    SYSTEM_TIMER_BASE_ADDRESS,                              // UINT64  CntControlBasePhysicalAddress
+    EFI_ACPI_RESERVED_DWORD,                                // UINT32  Reserved
+    FixedPcdGet32 (PcdArmArchTimerSecIntrNum),              // UINT32  SecurePL1TimerGSIV
+    GTDT_GTIMER_FLAGS,                                      // UINT32  SecurePL1TimerFlags
+    FixedPcdGet32 (PcdArmArchTimerIntrNum),                 // UINT32  NonSecurePL1TimerGSIV
+    GTDT_GTIMER_FLAGS,                                      // UINT32  NonSecurePL1TimerFlags
+    FixedPcdGet32 (PcdArmArchTimerVirtIntrNum),             // UINT32  VirtualTimerGSIV
+    GTDT_GTIMER_FLAGS,                                      // UINT32  VirtualTimerFlags
+    FixedPcdGet32 (PcdArmArchTimerHypIntrNum),              // UINT32  NonSecurePL2TimerGSIV
+    GTDT_GTIMER_FLAGS,                                      // UINT32  NonSecurePL2TimerFlags
+    CNT_READ_BASE_ADDRESS,                                  // UINT64  CntReadBasePhysicalAddress
+#if (WATCHDOG_COUNT != 0)
+    1                                                       // UINT32  PlatformTimerCount
+#else
+    0,                                                      // UINT32  PlatformTimerCount
+#endif
+    sizeof (EFI_ACPI_6_4_GENERIC_TIMER_DESCRIPTION_TABLE),  // UINT32  PlatformTimerOffset
+    0,                                                      // UINT32  VirtualPL2TimerGSIV
+    0                                                       // UINT32  VirtualPL2TimerFlags
+  },
+#if (WATCHDOG_COUNT != 0)
+  {
+    {
+      EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG,                      // UINT8 Type
+      sizeof(EFI_ACPI_6_4_GTDT_ARM_GENERIC_WATCHDOG_STRUCTURE),    // UINT16 Length
+      EFI_ACPI_RESERVED_BYTE,                                      // UINT8 Reserved
+      ARM_WATCHDOG_REFRESH_BASE,                                   // UINT64 RefreshFramePhysicalAddress
+      ARM_WATCHDOG_CONTROL_BASE,                                   // UINT64 WatchdogControlFramePhysicalAddress
+      ARM_WATCHDOG_GSIV,                                           // UINT32 WatchdogTimerGSIV
+      ARM_WATCHDOG_FLAGS                                           // UINT32 WatchdogTimerFlags
+    }
+  }
+#endif
+};
+
+
+// Reference the table being generated to prevent the optimizer from removing the
+// data structure from the executable
+VOID* CONST ReferenceAcpiTable = &Gtdt;

--- a/Silicon/Apple/T602XFamilyPkg/AcpiTables/MADT_Static.aslc
+++ b/Silicon/Apple/T602XFamilyPkg/AcpiTables/MADT_Static.aslc
@@ -68,40 +68,40 @@ MULTIPLE_APIC_DESCRIPTION_TABLE Madt = {
     // Cores are ordered by cluster. (Bootstrap first, then successive P-core/E-core clusters.)
     //
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Blizzard-0 (Bootstrap)
-        0, 0, GET_MPID(0, 0), EFI_ACPI_6_3_GIC_ENABLED, 50, 0,
+        0, 0, GET_MPIDR(0, 0, 0, 0), EFI_ACPI_6_3_GIC_ENABLED, 50, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Blizzard-1 (Bootstrap)
-        1, 1, GET_MPID(0, 1),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+        1, 1, GET_MPIDR(0, 0, 0, 1),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Blizzard-2 (Bootstrap)
-        2, 2, GET_MPID(0, 2),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+        2, 2, GET_MPIDR(0, 0, 0, 2),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
-    EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Blizzard-2 (Bootstrap)
-        3, 3, GET_MPID(0, 3),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+    EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Blizzard-3 (Bootstrap)
+        3, 3, GET_MPIDR(0, 0, 0, 3),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-0 (P-core cluster 0)
-        4, 4, GET_MPID(1, 0),  EFI_ACPI_6_3_GIC_ENABLED, 58, 0,
+        4, 4, GET_MPIDR(0, 1, 1, 0),  EFI_ACPI_6_3_GIC_ENABLED, 58, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-1 (P-core cluster 0)
-        5, 5, GET_MPID(1, 1),  EFI_ACPI_6_3_GIC_ENABLED, 62, 0,
+        5, 5, GET_MPIDR(0, 1, 1, 1),  EFI_ACPI_6_3_GIC_ENABLED, 62, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-2 (P-core cluster 0)
-        6, 6, GET_MPID(1, 2),  EFI_ACPI_6_3_GIC_ENABLED, 34, 0,
+        6, 6, GET_MPIDR(0, 1, 1, 2),  EFI_ACPI_6_3_GIC_ENABLED, 34, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // // Avalanche-3 (P-core cluster 0)
-        7, 7, GET_MPID(1, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        7, 7, GET_MPIDR(0, 1, 1, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-4 (P-core cluster 1)
-        8, 8, GET_MPID(2, 0),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        8, 8, GET_MPIDR(0, 1, 2, 0),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-5 (P-core cluster 1)
-        9, 9, GET_MPID(2, 1),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        9, 9, GET_MPIDR(0, 1, 2, 1),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-6 (P-core cluster 1)
-        10, 10, GET_MPID(2, 2),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        10, 10, GET_MPIDR(0, 1, 2, 2),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Avalanche-7 (P-core cluster 1)
-        11, 11, GET_MPID(2, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        11, 11, GET_MPIDR(0, 1, 2, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
 },
 EFI_ACPI_6_0_GIC_DISTRIBUTOR_INIT(0, FixedPcdGet64 (PcdGicDistributorBase), 0, 3),

--- a/Silicon/Apple/T602XFamilyPkg/AcpiTables/PPTT.aslc
+++ b/Silicon/Apple/T602XFamilyPkg/AcpiTables/PPTT.aslc
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2025 AppleWOA authors.
+ * 
+ * Module Name:
+ *     PPTT.aslc
+ * 
+ * Abstract:
+ *     Processor Properties Topology Table. Implements the
+ *     PPTT table for the T602x family -
+ *     This is only a temporary implementation 
+ *     until dynamic allocations in AcpiPlatformDxe are implemented.
+ * 
+ * Environment:
+ *     UEFI firmware/runtime services.
+ * 
+ * License:
+ *     SPDX-License-Identifier: BSD-2-Clause-Patent OR MIT
+ * 
+*/
+
+#include <Library/AcpiLib.h>
+#include <Library/ArmLib.h>
+#include <Library/PcdLib.h>
+#include <IndustryStandard/Acpi64.h>
+#include <Acpi/AcpiHeader.h>
+#include <Acpi/SgiAcpiHeader.h>
+
+
+#define DIE_COUNT               1 // this is *ignoring* the second die for now
+#define CLUSTER_COUNT           3 // bootstrap/E-core cluster, P-core cluster
+#define CLUSTER_CORE_COUNT      4 // 4 cores/cluster, note that for T600x
+#define PPTT_CPU_UID(DieId, ClusterId, CpuId)   ((ClusterId) * CLUSTER_CORE_COUNT + (CpuId))
+
+
+#pragma pack(1)
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Core;
+} PPTT_CORE;
+
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Cluster;
+    PPTT_CORE                              Cores[CLUSTER_CORE_COUNT];
+} PPTT_CLUSTER;
+
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Die;
+    PPTT_CLUSTER                           Clusters[CLUSTER_COUNT];
+} PPTT_DIE;
+#pragma pack ()
+
+
+#define CORE_INIT(DieId, ClusterId, CpuId)                                                          \
+{                                                                                                   \
+    /* Parameters for CPU Core */                                                                   \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        0x14,                                                           /* Length */                \
+        PPTT_PROCESSOR_CORE_FLAGS,                                      /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId]),                           /* Parent */                \
+        PPTT_CPU_UID(DieId, ClusterId, CpuId),                          /* ACPI Id */               \
+        0                                                               /* Private resources */     \
+    ),                                                                                              \
+}
+
+
+#define CLUSTER_INIT(DieId, ClusterId)                                                              \
+{                                                                                                   \
+    /* Parameters for Cluster */                                                                    \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        OFFSET_OF (PPTT_CLUSTER, Cores),                                /* Length */                \
+        PPTT_PROCESSOR_CLUSTER_FLAGS,                                   /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Die),                                           /* Parent */                \
+        ((DieId << 4) | ClusterId),                                     /* ACPI Id */               \
+        0                                                               /* Private resources */     \
+    ),                                                                                              \
+    {                                                                                               \
+        CORE_INIT (DieId, ClusterId, 0),                                                            \
+        CORE_INIT (DieId, ClusterId, 1),                                                            \
+        CORE_INIT (DieId, ClusterId, 2),                                                            \
+        CORE_INIT (DieId, ClusterId, 3),                                                            \
+    },                                                                                              \
+}
+
+#define DIE_INIT(DieId)                                                                             \
+{                                                                                                   \
+    /* Parameters for DIE (Package) */                                                              \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT(                                                     \
+        OFFSET_OF(PPTT_DIE, Clusters[0]),                               /* Length */                \
+        PPTT_PROCESSOR_PACKAGE_FLAGS,                                   /* Flag */                  \
+        0,                                                              /* Parent */                \
+        DieId,                                                          /* ACPI Id */               \
+        0                                                               /* Private resources */     \
+    ),                                                                                              \
+    {                                                                                               \
+        CLUSTER_INIT(DieId, 0),                                                                     \
+        CLUSTER_INIT(DieId, 1),                                                                     \
+        CLUSTER_INIT(DieId, 2),                                                                     \
+    }                                                                                               \
+}
+
+
+#pragma pack(1)
+typedef struct {
+    EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_HEADER  Header;
+    PPTT_DIE                                                 Dies[DIE_COUNT];
+} EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE;
+#pragma pack ()
+
+EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE Pptt = {
+{
+    __ACPI_HEADER (
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE,
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_REVISION
+    )
+    },
+    {
+        DIE_INIT(0),
+    }
+};
+
+VOID * CONST ReferenceAcpiTable = &Pptt;

--- a/Silicon/Apple/T602XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.inf
+++ b/Silicon/Apple/T602XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.inf
@@ -33,6 +33,8 @@
   DebugLib
   HobLib
   ArmMmuLib
+  AppleDTLib
+  PrintLib
 
 [Guids]
   gEfiMemoryTypeInformationGuid
@@ -61,6 +63,7 @@
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gAppleSiliconPkgTokenSpaceGuid.PcdFrameBufferAddress
   gAppleSiliconPkgTokenSpaceGuid.PcdFrameBufferSize
+  gAppleSiliconPkgTokenSpaceGuid.PcdCoreCount
 
 [Depex]
   TRUE

--- a/Silicon/Apple/T810XFamilyPkg/AcpiTables/CPUAcpiTables.inf
+++ b/Silicon/Apple/T810XFamilyPkg/AcpiTables/CPUAcpiTables.inf
@@ -19,6 +19,7 @@
 [Sources]
   GTDT.aslc
   MADT_Static.aslc
+  PPTT.aslc
 
 
 [Packages]

--- a/Silicon/Apple/T810XFamilyPkg/AcpiTables/MADT_Static.aslc
+++ b/Silicon/Apple/T810XFamilyPkg/AcpiTables/MADT_Static.aslc
@@ -82,28 +82,28 @@ MULTIPLE_APIC_DESCRIPTION_TABLE Madt = {
     // Cores are ordered by cluster. (Bootstrap first, then successive P-core/E-core clusters.)
     //
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Icestorm-0 (Bootstrap)
-        0, 0, GET_MPID(0, 0), EFI_ACPI_6_3_GIC_ENABLED, 50, 0,
+        0, 0, GET_MPIDR(0, 0, 0, 0), EFI_ACPI_6_3_GIC_ENABLED, 50, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Icestorm-1 (Bootstrap)
-        1, 1, GET_MPID(0, 1),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+        1, 1, GET_MPIDR(0, 0, 0, 1),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Icestorm-2 (Bootstrap)
-        2, 2, GET_MPID(0, 2),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+        2, 2, GET_MPIDR(0, 0, 0, 2),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Icestorm-2 (Bootstrap)
-        3, 3, GET_MPID(0, 3),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
+        3, 3, GET_MPIDR(0, 0, 0, 3),  EFI_ACPI_6_3_GIC_ENABLED, 54, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Firestorm-0 (P-core cluster 0)
-        4, 4, GET_MPID(1, 0),  EFI_ACPI_6_3_GIC_ENABLED, 58, 0,
+        4, 4, GET_MPIDR(0, 1, 1, 0),  EFI_ACPI_6_3_GIC_ENABLED, 58, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Firestorm-1 (P-core cluster 0)
-        5, 5, GET_MPID(1, 1),  EFI_ACPI_6_3_GIC_ENABLED, 62, 0,
+        5, 5, GET_MPIDR(0, 1, 1, 1),  EFI_ACPI_6_3_GIC_ENABLED, 62, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // Firestorm-2 (P-core cluster 0)
-        6, 6, GET_MPID(1, 2),  EFI_ACPI_6_3_GIC_ENABLED, 34, 0,
+        6, 6, GET_MPIDR(0, 1, 1, 2),  EFI_ACPI_6_3_GIC_ENABLED, 34, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
     EFI_ACPI_6_3_GICC_STRUCTURE_INIT( // // Firestorm-3 (P-core cluster 0)
-        7, 7, GET_MPID(1, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
+        7, 7, GET_MPIDR(0, 1, 1, 3),  EFI_ACPI_6_3_GIC_ENABLED, 38, 0,
         0, 0, 25, 0 /* GicRBase */, 0, 0),
 },
 EFI_ACPI_6_0_GIC_DISTRIBUTOR_INIT(0, FixedPcdGet64 (PcdGicDistributorBase), 0, 3),

--- a/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
+++ b/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
@@ -26,75 +26,20 @@
 #include <Acpi/SgiAcpiHeader.h>
 
 
-/*
-TTY> L1 Type: Separate I&D (ctype=3)
-TTY> L1 I: size=131072 bytes, line=64, ways=8, sets=256  [WA=0 RA=1 WB=0 WT=0]
-TTY>   PPTT: Type=Instruction  LineSize=64  Associativity=8  NumberOfSets=256  Size=131072  Allocation(Read=Yes,Write=No)  WritePolicy=Unknown
-TTY> L1 D/U: size=65536 bytes, line=64, ways=8, sets=128  [WA=1 RA=1 WB=1 WT=0]
-TTY>   PPTT: Type=Data/Unified  LineSize=64  Associativity=8  NumberOfSets=128  Size=65536  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
-TTY> L2 Type: Unified (ctype=4)
-TTY> L2 D/U: size=4194304 bytes, line=128, ways=16, sets=2048  [WA=1 RA=1 WB=1 WT=0]
-TTY>   PPTT: Type=Data/Unified  LineSize=128  Associativity=16  NumberOfSets=2048  Size=4194304  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
-
-TTY> L1 Type: Separate I&D (ctype=3)
-TTY> L1 I: size=196608 bytes, line=64, ways=6, sets=512  [WA=0 RA=1 WB=0 WT=0]
-TTY>   PPTT: Type=Instruction  LineSize=64  Associativity=6  NumberOfSets=512  Size=196608  Allocation(Read=Yes,Write=No)  WritePolicy=Unknown
-TTY> L1 D/U: size=131072 bytes, line=64, ways=8, sets=256  [WA=1 RA=1 WB=1 WT=0]
-TTY>   PPTT: Type=Data/Unified  LineSize=64  Associativity=8  NumberOfSets=256  Size=131072  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
-TTY> L2 Type: Unified (ctype=4)
-TTY> L2 D/U: size=12582912 bytes, line=128, ways=12, sets=8192  [WA=1 RA=1 WB=1 WT=0]
-TTY>   PPTT: Type=Data/Unified  LineSize=128  Associativity=12  NumberOfSets=8192  Size=12582912  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
-*/
-
 #define DIE_COUNT               1
 #define CLUSTER_COUNT           2
 #define CLUSTER_CORE_COUNT      4
-#define CPU_UID(DieId, ClusterId, CpuId)   ((ClusterId) * CLUSTER_CORE_COUNT + (CpuId))
-
-
-#define ECORE_L1I_LINE_SIZE     64
-#define ECORE_L1I_ASSOC         8
-#define ECORE_L1I_SIZE          SIZE_128KB
-#define ECORE_L1I_SETS          256
-
-#define ECORE_L1D_LINE_SIZE     64
-#define ECORE_L1D_ASSOC         8
-#define ECORE_L1D_SIZE          SIZE_64KB
-#define ECORE_L1D_SETS          128
-
-#define ECORE_L2_LINE_SIZE      128
-#define ECORE_L2_ASSOC          16
-#define ECORE_L2_SIZE           SIZE_4MB
-#define ECORE_L2_SETS           2048
-
-#define PCORE_L1I_LINE_SIZE     64
-#define PCORE_L1I_ASSOC         6
-#define PCORE_L1I_SIZE          SIZE_128KB + SIZE_64KB
-#define PCORE_L1I_SETS          512
-
-#define PCORE_L1D_LINE_SIZE     64
-#define PCORE_L1D_ASSOC         8
-#define PCORE_L1D_SIZE          SIZE_128KB
-#define PCORE_L1D_SETS          256
-
-#define PCORE_L2_LINE_SIZE      128
-#define PCORE_L2_ASSOC          12
-#define PCORE_L2_SIZE           SIZE_8MB + SIZE_4MB
-#define PCORE_L2_SETS           8192
+#define PPTT_CPU_UID(DieId, ClusterId, CpuId)   ((ClusterId) * CLUSTER_CORE_COUNT + (CpuId))
 
 
 #pragma pack(1)
 typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Core;
-    UINT32                                 ResourceOffset[2];
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      DCache;
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      ICache;
 } PPTT_CORE;
 
 typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Cluster;
     PPTT_CORE                              Cores[CLUSTER_CORE_COUNT];
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      L2Cache;
 } PPTT_CLUSTER;
 
 typedef struct {
@@ -104,96 +49,21 @@ typedef struct {
 #pragma pack ()
 
 
-#define ECORE_INIT(DieId, ClusterId, CpuId)                                                         \
+#define CORE_INIT(DieId, ClusterId, CpuId)                                                          \
 {                                                                                                   \
     /* Parameters for CPU Core */                                                                   \
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
-        OFFSET_OF (PPTT_CORE, DCache),                                  /* Length */                \
+        0x14,                                                           /* Length */                \
         PPTT_PROCESSOR_CORE_FLAGS,                                      /* Flag */                  \
         OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
             Dies[DieId].Clusters[ClusterId]),                           /* Parent */                \
-        CPU_UID(DieId, ClusterId, CpuId),                               /* ACPI Id */               \
-        2                                                               /* Private resources */     \
-    ),                                                                                              \
-    /* Offsets of the private resources */                                                          \
-    {                                                                                               \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].DCache),                                   \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].ICache)                                    \
-    },                                                                                              \
-    /* L1 data cache parameters */                                                                  \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
-        ECORE_L1D_SIZE,                                                 /* Size */                  \
-        ECORE_L1D_SETS,                                                 /* Num of sets */           \
-        ECORE_L1D_ASSOC,                                                /* Associativity */         \
-        PPTT_DATA_CACHE_ATTR,                                           /* Attributes */            \
-        ECORE_L1D_LINE_SIZE,                                            /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1DataCache)          /* Cache id */              \
-    ),                                                                                              \
-    /* L1 instruction cache parameters */                                                           \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
-        ECORE_L1I_SIZE,                                                 /* Size */                  \
-        ECORE_L1I_SETS,                                                 /* Num of sets */           \
-        ECORE_L1I_ASSOC,                                                /* Associativity */         \
-        PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
-        ECORE_L1I_LINE_SIZE,                                            /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
-    ),                                                                                              \
-}
-
-#define PCORE_INIT(DieId, ClusterId, CpuId)                                                         \
-{                                                                                                   \
-    /* Parameters for CPU Core */                                                                   \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
-        OFFSET_OF (PPTT_CORE, DCache),                                  /* Length */                \
-        PPTT_PROCESSOR_CORE_FLAGS,                                      /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId]),                           /* Parent */                \
-        CPU_UID(DieId, ClusterId, CpuId),                               /* ACPI Id */               \
-        2                                                               /* Private resources */     \
-    ),                                                                                              \
-    /* Offsets of the private resources */                                                          \
-    {                                                                                               \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].DCache),                                   \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].ICache)                                    \
-    },                                                                                              \
-    /* L1 data cache parameters */                                                                  \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
-        PCORE_L1D_SIZE,                                                 /* Size */                  \
-        PCORE_L1D_SETS,                                                 /* Num of sets */           \
-        PCORE_L1D_ASSOC,                                                /* Associativity */         \
-        PPTT_DATA_CACHE_ATTR,                                           /* Attributes */            \
-        PCORE_L1D_LINE_SIZE,                                            /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1DataCache)          /* Cache id */              \
-    ),                                                                                              \
-    /* L1 instruction cache parameters */                                                           \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
-        PCORE_L1I_SIZE,                                                 /* Size */                  \
-        PCORE_L1I_SETS,                                                 /* Num of sets */           \
-        PCORE_L1I_ASSOC,                                                /* Associativity */         \
-        PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
-        PCORE_L1I_LINE_SIZE,                                            /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
+        PPTT_CPU_UID(DieId, ClusterId, CpuId),                          /* ACPI Id */               \
+        0                                                               /* Private resources */     \
     ),                                                                                              \
 }
 
 
-#define E_CLUSTER_INIT(DieId, ClusterId)                                                            \
+#define CLUSTER_INIT(DieId, ClusterId)                                                              \
 {                                                                                                   \
     /* Parameters for Cluster */                                                                    \
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
@@ -205,67 +75,26 @@ typedef struct {
         0                                                               /* Private resources */     \
     ),                                                                                              \
     {                                                                                               \
-        ECORE_INIT (DieId, ClusterId, 0),                                                           \
-        ECORE_INIT (DieId, ClusterId, 1),                                                           \
-        ECORE_INIT (DieId, ClusterId, 2),                                                           \
-        ECORE_INIT (DieId, ClusterId, 3),                                                           \
+        CORE_INIT (DieId, ClusterId, 0),                                                            \
+        CORE_INIT (DieId, ClusterId, 1),                                                            \
+        CORE_INIT (DieId, ClusterId, 2),                                                            \
+        CORE_INIT (DieId, ClusterId, 3),                                                            \
     },                                                                                              \
-    /* L2 cache parameters */                                                                       \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        0,                                                              /* Next cache */            \
-        ECORE_L2_SIZE,                                                  /* Size */                  \
-        ECORE_L2_SETS,                                                  /* Num of sets */           \
-        ECORE_L2_ASSOC,                                                 /* Associativity */         \
-        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
-        ECORE_L2_LINE_SIZE,                                             /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, 0, L2Cache)                  /* Cache id */              \
-    ),                                                                                              \
-}
-
-#define P_CLUSTER_INIT(DieId, ClusterId)                                                            \
-{                                                                                                   \
-    /* Parameters for Cluster */                                                                    \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
-        OFFSET_OF (PPTT_CLUSTER, Cores),                                /* Length */                \
-        PPTT_PROCESSOR_CLUSTER_FLAGS,                                   /* Flag */                  \
-        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Die),                                           /* Parent */                \
-        ((DieId << 4) | ClusterId),                                     /* ACPI Id */               \
-        0                                                               /* Private resources */     \
-    ),                                                                                              \
-    {                                                                                               \
-        PCORE_INIT (DieId, ClusterId, 0),                                                           \
-        PCORE_INIT (DieId, ClusterId, 1),                                                           \
-        PCORE_INIT (DieId, ClusterId, 2),                                                           \
-        PCORE_INIT (DieId, ClusterId, 3),                                                           \
-    },                                                                                              \
-    /* L2 cache parameters */                                                                       \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        0,                                                              /* Next cache */            \
-        PCORE_L2_SIZE,                                                  /* Size */                  \
-        PCORE_L2_SETS,                                                  /* Num of sets */           \
-        PCORE_L2_ASSOC,                                                 /* Associativity */         \
-        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
-        PCORE_L2_LINE_SIZE,                                             /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, 0, L2Cache)                  /* Cache id */              \
-    ),                                                                                              \
 }
 
 #define DIE_INIT(DieId)                                                                             \
 {                                                                                                   \
-    /* DIE processor node (length up to Clusters[0]) */                                             \
+    /* Parameters for DIE (Package) */                                                              \
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT(                                                     \
-        OFFSET_OF(PPTT_DIE, Clusters[0]),                                                           \
-        PPTT_PROCESSOR_PACKAGE_FLAGS,                                                               \
-        0, /* parent = none */                                                                      \
-        DieId,                                                                                      \
-        0                                                                                           \
+        OFFSET_OF(PPTT_DIE, Clusters[0]),                               /* Length */                \
+        PPTT_PROCESSOR_PACKAGE_FLAGS,                                   /* Flag */                  \
+        0,                                                              /* Parent */                \
+        DieId,                                                          /* ACPI Id */               \
+        0                                                               /* Private resources */     \
     ),                                                                                              \
     {                                                                                               \
-        E_CLUSTER_INIT(DieId, 0),                                                                   \
-        P_CLUSTER_INIT(DieId, 1),                                                                   \
+        CLUSTER_INIT(DieId, 0),                                                                     \
+        CLUSTER_INIT(DieId, 1),                                                                     \
     }                                                                                               \
 }
 

--- a/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
+++ b/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
@@ -89,12 +89,12 @@ typedef struct {
     UINT32                                 ResourceOffset[2];
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      DCache;
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      ICache;
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      L2Cache;
 } PPTT_CORE;
 
 typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Cluster;
     PPTT_CORE                              Cores[CLUSTER_CORE_COUNT];
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      L2Cache;
 } PPTT_CLUSTER;
 
 typedef struct {
@@ -126,7 +126,7 @@ typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
         PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
         OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
         ECORE_L1D_SIZE,                                                 /* Size */                  \
         ECORE_L1D_SETS,                                                 /* Num of sets */           \
         ECORE_L1D_ASSOC,                                                /* Associativity */         \
@@ -138,24 +138,13 @@ typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
         PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
         OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
         ECORE_L1I_SIZE,                                                 /* Size */                  \
         ECORE_L1I_SETS,                                                 /* Num of sets */           \
         ECORE_L1I_ASSOC,                                                /* Associativity */         \
         PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
         ECORE_L1I_LINE_SIZE,                                            /* Line size */             \
         RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
-    ),                                                                                              \
-    /* L2 cache parameters */                                                                       \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        0,                                                              /* Next cache */            \
-        ECORE_L2_SIZE,                                                  /* Size */                  \
-        ECORE_L2_SETS,                                                  /* Num of sets */           \
-        ECORE_L2_ASSOC,                                                 /* Associativity */         \
-        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
-        ECORE_L2_LINE_SIZE,                                             /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L2Cache)              /* Cache id */              \
     ),                                                                                              \
 }
 
@@ -181,7 +170,7 @@ typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
         PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
         OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
         PCORE_L1D_SIZE,                                                 /* Size */                  \
         PCORE_L1D_SETS,                                                 /* Num of sets */           \
         PCORE_L1D_ASSOC,                                                /* Associativity */         \
@@ -193,24 +182,13 @@ typedef struct {
     EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
         PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
         OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
-            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+            Dies[DieId].Clusters[ClusterId].L2Cache),                   /* Next cache */            \
         PCORE_L1I_SIZE,                                                 /* Size */                  \
         PCORE_L1I_SETS,                                                 /* Num of sets */           \
         PCORE_L1I_ASSOC,                                                /* Associativity */         \
         PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
         PCORE_L1I_LINE_SIZE,                                            /* Line size */             \
         RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
-    ),                                                                                              \
-    /* L2 cache parameters */                                                                       \
-    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
-        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
-        0,                                                              /* Next cache */            \
-        PCORE_L2_SIZE,                                                  /* Size */                  \
-        PCORE_L2_SETS,                                                  /* Num of sets */           \
-        PCORE_L2_ASSOC,                                                 /* Associativity */         \
-        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
-        PCORE_L2_LINE_SIZE,                                             /* Line size */             \
-        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L2Cache)              /* Cache id */              \
     ),                                                                                              \
 }
 
@@ -231,7 +209,18 @@ typedef struct {
         ECORE_INIT (DieId, ClusterId, 1),                                                           \
         ECORE_INIT (DieId, ClusterId, 2),                                                           \
         ECORE_INIT (DieId, ClusterId, 3),                                                           \
-    }                                                                                               \
+    },                                                                                              \
+    /* L2 cache parameters */                                                                       \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        0,                                                              /* Next cache */            \
+        ECORE_L2_SIZE,                                                  /* Size */                  \
+        ECORE_L2_SETS,                                                  /* Num of sets */           \
+        ECORE_L2_ASSOC,                                                 /* Associativity */         \
+        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
+        ECORE_L2_LINE_SIZE,                                             /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, 0, L2Cache)                  /* Cache id */              \
+    ),                                                                                              \
 }
 
 #define P_CLUSTER_INIT(DieId, ClusterId)                                                            \
@@ -250,7 +239,18 @@ typedef struct {
         PCORE_INIT (DieId, ClusterId, 1),                                                           \
         PCORE_INIT (DieId, ClusterId, 2),                                                           \
         PCORE_INIT (DieId, ClusterId, 3),                                                           \
-    }                                                                                               \
+    },                                                                                              \
+    /* L2 cache parameters */                                                                       \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        0,                                                              /* Next cache */            \
+        PCORE_L2_SIZE,                                                  /* Size */                  \
+        PCORE_L2_SETS,                                                  /* Num of sets */           \
+        PCORE_L2_ASSOC,                                                 /* Associativity */         \
+        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
+        PCORE_L2_LINE_SIZE,                                             /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, 0, L2Cache)                  /* Cache id */              \
+    ),                                                                                              \
 }
 
 #define DIE_INIT(DieId)                                                                             \

--- a/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
+++ b/Silicon/Apple/T810XFamilyPkg/AcpiTables/PPTT.aslc
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2025 AppleWOA authors.
+ * 
+ * Module Name:
+ *     PPTT.aslc
+ * 
+ * Abstract:
+ *     Processor Properties Topology Table. Implements the
+ *     PPTT table for the T810X family -
+ *     This is only a temporary implementation 
+ *     until dynamic allocations in AcpiPlatformDxe are implemented.
+ * 
+ * Environment:
+ *     UEFI firmware/runtime services.
+ * 
+ * License:
+ *     SPDX-License-Identifier: BSD-2-Clause-Patent OR MIT
+ * 
+*/
+
+#include <Library/AcpiLib.h>
+#include <Library/ArmLib.h>
+#include <Library/PcdLib.h>
+#include <IndustryStandard/Acpi64.h>
+#include <Acpi/AcpiHeader.h>
+#include <Acpi/SgiAcpiHeader.h>
+
+
+/*
+TTY> L1 Type: Separate I&D (ctype=3)
+TTY> L1 I: size=131072 bytes, line=64, ways=8, sets=256  [WA=0 RA=1 WB=0 WT=0]
+TTY>   PPTT: Type=Instruction  LineSize=64  Associativity=8  NumberOfSets=256  Size=131072  Allocation(Read=Yes,Write=No)  WritePolicy=Unknown
+TTY> L1 D/U: size=65536 bytes, line=64, ways=8, sets=128  [WA=1 RA=1 WB=1 WT=0]
+TTY>   PPTT: Type=Data/Unified  LineSize=64  Associativity=8  NumberOfSets=128  Size=65536  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
+TTY> L2 Type: Unified (ctype=4)
+TTY> L2 D/U: size=4194304 bytes, line=128, ways=16, sets=2048  [WA=1 RA=1 WB=1 WT=0]
+TTY>   PPTT: Type=Data/Unified  LineSize=128  Associativity=16  NumberOfSets=2048  Size=4194304  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
+
+TTY> L1 Type: Separate I&D (ctype=3)
+TTY> L1 I: size=196608 bytes, line=64, ways=6, sets=512  [WA=0 RA=1 WB=0 WT=0]
+TTY>   PPTT: Type=Instruction  LineSize=64  Associativity=6  NumberOfSets=512  Size=196608  Allocation(Read=Yes,Write=No)  WritePolicy=Unknown
+TTY> L1 D/U: size=131072 bytes, line=64, ways=8, sets=256  [WA=1 RA=1 WB=1 WT=0]
+TTY>   PPTT: Type=Data/Unified  LineSize=64  Associativity=8  NumberOfSets=256  Size=131072  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
+TTY> L2 Type: Unified (ctype=4)
+TTY> L2 D/U: size=12582912 bytes, line=128, ways=12, sets=8192  [WA=1 RA=1 WB=1 WT=0]
+TTY>   PPTT: Type=Data/Unified  LineSize=128  Associativity=12  NumberOfSets=8192  Size=12582912  Allocation(Read=Yes,Write=Yes)  WritePolicy=WriteBack
+*/
+
+#define DIE_COUNT               1
+#define CLUSTER_COUNT           2
+#define CLUSTER_CORE_COUNT      4
+#define CPU_UID(DieId, ClusterId, CpuId)   ((ClusterId) * CLUSTER_CORE_COUNT + (CpuId))
+
+
+#define ECORE_L1I_LINE_SIZE     64
+#define ECORE_L1I_ASSOC         8
+#define ECORE_L1I_SIZE          SIZE_128KB
+#define ECORE_L1I_SETS          256
+
+#define ECORE_L1D_LINE_SIZE     64
+#define ECORE_L1D_ASSOC         8
+#define ECORE_L1D_SIZE          SIZE_64KB
+#define ECORE_L1D_SETS          128
+
+#define ECORE_L2_LINE_SIZE      128
+#define ECORE_L2_ASSOC          16
+#define ECORE_L2_SIZE           SIZE_4MB
+#define ECORE_L2_SETS           2048
+
+#define PCORE_L1I_LINE_SIZE     64
+#define PCORE_L1I_ASSOC         6
+#define PCORE_L1I_SIZE          SIZE_128KB + SIZE_64KB
+#define PCORE_L1I_SETS          512
+
+#define PCORE_L1D_LINE_SIZE     64
+#define PCORE_L1D_ASSOC         8
+#define PCORE_L1D_SIZE          SIZE_128KB
+#define PCORE_L1D_SETS          256
+
+#define PCORE_L2_LINE_SIZE      128
+#define PCORE_L2_ASSOC          12
+#define PCORE_L2_SIZE           SIZE_8MB + SIZE_4MB
+#define PCORE_L2_SETS           8192
+
+
+#pragma pack(1)
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Core;
+    UINT32                                 ResourceOffset[2];
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      DCache;
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      ICache;
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE      L2Cache;
+} PPTT_CORE;
+
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Cluster;
+    PPTT_CORE                              Cores[CLUSTER_CORE_COUNT];
+} PPTT_CLUSTER;
+
+typedef struct {
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR  Die;
+    PPTT_CLUSTER                           Clusters[CLUSTER_COUNT];
+} PPTT_DIE;
+#pragma pack ()
+
+
+#define ECORE_INIT(DieId, ClusterId, CpuId)                                                         \
+{                                                                                                   \
+    /* Parameters for CPU Core */                                                                   \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        OFFSET_OF (PPTT_CORE, DCache),                                  /* Length */                \
+        PPTT_PROCESSOR_CORE_FLAGS,                                      /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId]),                           /* Parent */                \
+        CPU_UID(DieId, ClusterId, CpuId),                               /* ACPI Id */               \
+        2                                                               /* Private resources */     \
+    ),                                                                                              \
+    /* Offsets of the private resources */                                                          \
+    {                                                                                               \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].DCache),                                   \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].ICache)                                    \
+    },                                                                                              \
+    /* L1 data cache parameters */                                                                  \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+        ECORE_L1D_SIZE,                                                 /* Size */                  \
+        ECORE_L1D_SETS,                                                 /* Num of sets */           \
+        ECORE_L1D_ASSOC,                                                /* Associativity */         \
+        PPTT_DATA_CACHE_ATTR,                                           /* Attributes */            \
+        ECORE_L1D_LINE_SIZE,                                            /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1DataCache)          /* Cache id */              \
+    ),                                                                                              \
+    /* L1 instruction cache parameters */                                                           \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+        ECORE_L1I_SIZE,                                                 /* Size */                  \
+        ECORE_L1I_SETS,                                                 /* Num of sets */           \
+        ECORE_L1I_ASSOC,                                                /* Associativity */         \
+        PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
+        ECORE_L1I_LINE_SIZE,                                            /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
+    ),                                                                                              \
+    /* L2 cache parameters */                                                                       \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        0,                                                              /* Next cache */            \
+        ECORE_L2_SIZE,                                                  /* Size */                  \
+        ECORE_L2_SETS,                                                  /* Num of sets */           \
+        ECORE_L2_ASSOC,                                                 /* Associativity */         \
+        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
+        ECORE_L2_LINE_SIZE,                                             /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L2Cache)              /* Cache id */              \
+    ),                                                                                              \
+}
+
+#define PCORE_INIT(DieId, ClusterId, CpuId)                                                         \
+{                                                                                                   \
+    /* Parameters for CPU Core */                                                                   \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        OFFSET_OF (PPTT_CORE, DCache),                                  /* Length */                \
+        PPTT_PROCESSOR_CORE_FLAGS,                                      /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId]),                           /* Parent */                \
+        CPU_UID(DieId, ClusterId, CpuId),                               /* ACPI Id */               \
+        2                                                               /* Private resources */     \
+    ),                                                                                              \
+    /* Offsets of the private resources */                                                          \
+    {                                                                                               \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].DCache),                                   \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].ICache)                                    \
+    },                                                                                              \
+    /* L1 data cache parameters */                                                                  \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+        PCORE_L1D_SIZE,                                                 /* Size */                  \
+        PCORE_L1D_SETS,                                                 /* Num of sets */           \
+        PCORE_L1D_ASSOC,                                                /* Associativity */         \
+        PPTT_DATA_CACHE_ATTR,                                           /* Attributes */            \
+        PCORE_L1D_LINE_SIZE,                                            /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1DataCache)          /* Cache id */              \
+    ),                                                                                              \
+    /* L1 instruction cache parameters */                                                           \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Clusters[ClusterId].Cores[CpuId].L2Cache),      /* Next cache */            \
+        PCORE_L1I_SIZE,                                                 /* Size */                  \
+        PCORE_L1I_SETS,                                                 /* Num of sets */           \
+        PCORE_L1I_ASSOC,                                                /* Associativity */         \
+        PPTT_INST_CACHE_ATTR,                                           /* Attributes */            \
+        PCORE_L1I_LINE_SIZE,                                            /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L1InstructionCache)   /* Cache id */              \
+    ),                                                                                              \
+    /* L2 cache parameters */                                                                       \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_CACHE_INIT (                                                        \
+        PPTT_CACHE_STRUCTURE_FLAGS,                                     /* Flag */                  \
+        0,                                                              /* Next cache */            \
+        PCORE_L2_SIZE,                                                  /* Size */                  \
+        PCORE_L2_SETS,                                                  /* Num of sets */           \
+        PCORE_L2_ASSOC,                                                 /* Associativity */         \
+        PPTT_UNIFIED_CACHE_ATTR,                                        /* Attributes */            \
+        PCORE_L2_LINE_SIZE,                                             /* Line size */             \
+        RD_PPTT_CACHE_ID(DieId, ClusterId, CpuId, L2Cache)              /* Cache id */              \
+    ),                                                                                              \
+}
+
+
+#define E_CLUSTER_INIT(DieId, ClusterId)                                                            \
+{                                                                                                   \
+    /* Parameters for Cluster */                                                                    \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        OFFSET_OF (PPTT_CLUSTER, Cores),                                /* Length */                \
+        PPTT_PROCESSOR_CLUSTER_FLAGS,                                   /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Die),                                           /* Parent */                \
+        ((DieId << 4) | ClusterId),                                     /* ACPI Id */               \
+        0                                                               /* Private resources */     \
+    ),                                                                                              \
+    {                                                                                               \
+        ECORE_INIT (DieId, ClusterId, 0),                                                           \
+        ECORE_INIT (DieId, ClusterId, 1),                                                           \
+        ECORE_INIT (DieId, ClusterId, 2),                                                           \
+        ECORE_INIT (DieId, ClusterId, 3),                                                           \
+    }                                                                                               \
+}
+
+#define P_CLUSTER_INIT(DieId, ClusterId)                                                            \
+{                                                                                                   \
+    /* Parameters for Cluster */                                                                    \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT (                                                    \
+        OFFSET_OF (PPTT_CLUSTER, Cores),                                /* Length */                \
+        PPTT_PROCESSOR_CLUSTER_FLAGS,                                   /* Flag */                  \
+        OFFSET_OF (EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,                                \
+            Dies[DieId].Die),                                           /* Parent */                \
+        ((DieId << 4) | ClusterId),                                     /* ACPI Id */               \
+        0                                                               /* Private resources */     \
+    ),                                                                                              \
+    {                                                                                               \
+        PCORE_INIT (DieId, ClusterId, 0),                                                           \
+        PCORE_INIT (DieId, ClusterId, 1),                                                           \
+        PCORE_INIT (DieId, ClusterId, 2),                                                           \
+        PCORE_INIT (DieId, ClusterId, 3),                                                           \
+    }                                                                                               \
+}
+
+#define DIE_INIT(DieId)                                                                             \
+{                                                                                                   \
+    /* DIE processor node (length up to Clusters[0]) */                                             \
+    EFI_ACPI_6_4_PPTT_STRUCTURE_PROCESSOR_INIT(                                                     \
+        OFFSET_OF(PPTT_DIE, Clusters[0]),                                                           \
+        PPTT_PROCESSOR_PACKAGE_FLAGS,                                                               \
+        0, /* parent = none */                                                                      \
+        DieId,                                                                                      \
+        0                                                                                           \
+    ),                                                                                              \
+    {                                                                                               \
+        E_CLUSTER_INIT(DieId, 0),                                                                   \
+        P_CLUSTER_INIT(DieId, 1),                                                                   \
+    }                                                                                               \
+}
+
+
+#pragma pack(1)
+typedef struct {
+    EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_HEADER  Header;
+    PPTT_DIE                                                 Dies[DIE_COUNT];
+} EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE;
+#pragma pack ()
+
+EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE Pptt = {
+{
+    __ACPI_HEADER (
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_STRUCTURE_SIGNATURE,
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE,
+        EFI_ACPI_6_4_PROCESSOR_PROPERTIES_TOPOLOGY_TABLE_REVISION
+    )
+    },
+    {
+        DIE_INIT(0),
+    }
+};
+
+VOID * CONST ReferenceAcpiTable = &Pptt;

--- a/Silicon/Apple/T810XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.c
+++ b/Silicon/Apple/T810XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.c
@@ -24,6 +24,8 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Library/IoLib.h>
+#include <Library/PrintLib.h>
+#include <Library/AppleDTLib.h>
 
 //Device memory map configuration file for UEFI (this is to help with pagetable initialization)
 #include <Library/T810XFamilyVirtualMemoryMapDefines.h>
@@ -54,6 +56,84 @@ STATIC VOID InitMmu(IN ARM_MEMORY_REGION_DESCRIPTOR *MemoryTable)
     {
         DEBUG((DEBUG_ERROR | DEBUG_INFO, "MemoryInitPeiLib: MMU enable failed!! Status: %llx\n", StatusCode));
     }
+}
+
+//borrowed from edk2-platforms:Armada7k8kMemoryInitPeiLib
+STATIC VOID ReserveMemoryRegion ( IN EFI_PHYSICAL_ADDRESS ReservedRegionBase, IN UINT32 ReservedRegionSize)
+{
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttributes;
+  EFI_PHYSICAL_ADDRESS         ReservedRegionTop;
+  EFI_PHYSICAL_ADDRESS         ResourceTop;
+  EFI_PEI_HOB_POINTERS         NextHob;
+  UINT64                       ResourceLength;
+
+  ReservedRegionTop = ReservedRegionBase + ReservedRegionSize;
+
+  //
+  // Search for System Memory Hob that covers the reserved region,
+  // and punch a hole in it
+  //
+  for (NextHob.Raw = GetHobList ();
+       NextHob.Raw != NULL;
+       NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR,
+                                 NextHob.Raw)) {
+
+    if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
+        (ReservedRegionBase >= NextHob.ResourceDescriptor->PhysicalStart) &&
+        (ReservedRegionTop <= NextHob.ResourceDescriptor->PhysicalStart +
+                      NextHob.ResourceDescriptor->ResourceLength))
+    {
+      ResourceAttributes = NextHob.ResourceDescriptor->ResourceAttribute;
+      ResourceLength = NextHob.ResourceDescriptor->ResourceLength;
+      ResourceTop = NextHob.ResourceDescriptor->PhysicalStart + ResourceLength;
+
+      if (ReservedRegionBase == NextHob.ResourceDescriptor->PhysicalStart) {
+        //
+        // This region starts right at the start of the reserved region, so we
+        // can simply move its start pointer and reduce its length by the same
+        // value
+        //
+        NextHob.ResourceDescriptor->PhysicalStart += ReservedRegionSize;
+        NextHob.ResourceDescriptor->ResourceLength -= ReservedRegionSize;
+
+      } else if ((NextHob.ResourceDescriptor->PhysicalStart +
+                  NextHob.ResourceDescriptor->ResourceLength) ==
+                  ReservedRegionTop) {
+
+        //
+        // This region ends right at the end of the reserved region, so we
+        // can simply reduce its length by the size of the region.
+        //
+        NextHob.ResourceDescriptor->ResourceLength -= ReservedRegionSize;
+
+      } else {
+        //
+        // This region covers the reserved region. So split it into two regions,
+        // each one touching the reserved region at either end, but not covering
+        // it.
+        //
+        NextHob.ResourceDescriptor->ResourceLength =
+                 ReservedRegionBase - NextHob.ResourceDescriptor->PhysicalStart;
+
+        // Create the System Memory HOB for the remaining region (top of the FD)
+        BuildResourceDescriptorHob (EFI_RESOURCE_SYSTEM_MEMORY,
+                                    ResourceAttributes,
+                                    ReservedRegionTop,
+                                    ResourceTop - ReservedRegionTop);
+      }
+
+      //
+      // Reserve the memory space.
+      //
+      BuildResourceDescriptorHob (EFI_RESOURCE_MEMORY_RESERVED,
+        0,
+        ReservedRegionBase,
+        ReservedRegionSize);
+
+      break;
+    }
+    NextHob.Raw = GET_NEXT_HOB (NextHob);
+  }
 }
 
 
@@ -192,6 +272,23 @@ EFI_STATUS EFIAPI MemoryPeim(IN EFI_PHYSICAL_ADDRESS UefiMemoryBase, IN UINT64 U
 
     ASSERT (Found);
   }
+  
+  //reserve secondary stacks carveouts passed into cpm-impl-reg 
+  for(int i = 0; i < PcdGet32(PcdCoreCount); i++){
+    CHAR8 CpuNodeName[14];
+    UINTN CarveoutLength = 0;
+
+    AsciiSPrint(CpuNodeName, ARRAY_SIZE(CpuNodeName), "/cpus/cpu%d", i);
+    dt_node_t *CpuNode = dt_get(CpuNodeName);
+    UINT32 *Carveout = (UINT32 *)dt_node_prop(CpuNode, "cpm-impl-reg", &CarveoutLength);
+
+    ReserveMemoryRegion (
+      ((UINT64)Carveout[1] << 32) | Carveout[0],
+      ((UINT64)Carveout[3] << 32) | Carveout[2]
+    );
+  }
+
+
 
   // Build Memory Allocation Hob
   InitMmu (MemoryTable);

--- a/Silicon/Apple/T810XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.inf
+++ b/Silicon/Apple/T810XFamilyPkg/Library/MemoryInitPeiLib/MemoryInitPeiLib.inf
@@ -33,6 +33,8 @@
   DebugLib
   HobLib
   ArmMmuLib
+  AppleDTLib
+  PrintLib
 
 [Guids]
   gEfiMemoryTypeInformationGuid
@@ -61,5 +63,6 @@
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gAppleSiliconPkgTokenSpaceGuid.PcdFrameBufferAddress
   gAppleSiliconPkgTokenSpaceGuid.PcdFrameBufferSize
+  gAppleSiliconPkgTokenSpaceGuid.PcdCoreCount
 [Depex]
   TRUE


### PR DESCRIPTION
- Each secondary stack was patched by m1n1 into ADT at `/cpus/cpu%d/cpm-impl-reg` so we can reserve it
- Add PPTT table for proper socket/core count reporting
- Set correct MPIDR value into MADT so it matches MPIDR_EL1. Makes Windows able to initialize P clusters